### PR TITLE
validation function for zod schemas

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,13 @@
+import { ZodObject, ZodRawShape, ZodSchema } from 'zod';
+
 export const ErrorMessage = (e: any) => {
   return { message: e instanceof Error ? e.message : 'An unknown error occurred' };
 };
+
+export function validate<T>(object: any , schema: ZodSchema<T>) {
+  return  schema.safeParse(object);
+}
+
+export function validateUpdate<T extends ZodRawShape>(object: any , schema: ZodObject<T> ) {
+  return schema.partial().safeParse(object);
+}


### PR DESCRIPTION
Se añaden dos funciones globales para validar schemas de zod genéricamente , de esta forma podemos usar la misma función de validar para todos los esquemas