### PR TITLE
updated QueryBuilder for equipment

### DIFF
--- a/src/db/schemas/equipment.ts
+++ b/src/db/schemas/equipment.ts
@@ -7,7 +7,7 @@ export const equipment = pgTable('equipment', {
   type: varchar('type', { length: 255 }).notNull(),
   state: varchar('state', { length: 255 }).notNull(),
   id_department: uuid('id_department').references(() => department.id),
-  acquisition_date: timestamp('acquisition_date').defaultNow().notNull()
+  acquisition_date: timestamp('acquisition_date' , {mode:'string'}).defaultNow().notNull()
 });
 
 export type Equipment = typeof equipment.$inferSelect;

--- a/src/features/Equipment/controller.ts
+++ b/src/features/Equipment/controller.ts
@@ -1,7 +1,7 @@
 import { IEquipmentModel } from '../Interfaces/IEquipmentModel';
 import { Request, Response } from 'express';
 import { ErrorMessage, validate, validateUpdate } from '../../utils';
-import { equipmentSchema } from './utils';
+import { EquipmentQuery, EquipmentQueryBuilder, equipmentSchema } from './utils';
 import { Equipment, NewEquipment } from '../../db/schemas/equipment';
 import crypto from 'node:crypto';
 
@@ -20,7 +20,6 @@ export class EquipmentController {
       }
       //TODO Verify if equipment department exist before insert
       const equipmentData: NewEquipment = {
-        id: crypto.randomUUID(),
         ...result.data
       };
       const newEquipment = await this.equipmentModel.create(equipmentData);
@@ -42,7 +41,9 @@ export class EquipmentController {
   getById = async (req: Request, res: Response) => {
     try {
       const id = req.params.id;
-      const equipment = await this.equipmentModel.getById(id);
+      const equipmentQuery = { id: id };
+      const filter = EquipmentQueryBuilder(equipmentQuery);
+      const equipment = await this.equipmentModel.getById(filter);
       if (!equipment) {
         res.status(404).json({ message: 'Equipment not found' });
         return;
@@ -61,12 +62,14 @@ export class EquipmentController {
         return;
       }
       const equipmentData: Partial<Equipment> = { ...result.data };
-      const equipment = await this.equipmentModel.getById(id);
+      const equipmentQuery : EquipmentQuery = { id: id };
+      const filter = EquipmentQueryBuilder(equipmentQuery);
+      const equipment = await this.equipmentModel.getById(filter);
       if (!equipment) {
         res.status(404).json({ message: 'Equipment not found' });
         return;
       }
-      const updatedEquipment = await this.equipmentModel.update(id, equipmentData);
+      const updatedEquipment = await this.equipmentModel.update(filter, equipmentData);
       res.status(200).json(updatedEquipment);
     } catch (e) {
       res.status(500).json(ErrorMessage(e));
@@ -76,12 +79,14 @@ export class EquipmentController {
   delete = async (req: Request, res: Response) => {
     try {
       const id = req.params.id;
-      const equipment = await this.equipmentModel.getById(id);
+      const equipmentQuery : EquipmentQuery = { id: id };
+      const filter = EquipmentQueryBuilder(equipmentQuery);
+      const equipment = await this.equipmentModel.getById(filter);
       if (!equipment) {
         res.status(404).json({ message: 'Equipment not found' });
         return;
       }
-      await this.equipmentModel.delete(id);
+      await this.equipmentModel.delete(filter);
       res.status(200).json({ message: 'Equipment deleted successfully' });
     } catch (e) {
       res.status(500).json(ErrorMessage(e));

--- a/src/features/Equipment/model.ts
+++ b/src/features/Equipment/model.ts
@@ -1,7 +1,7 @@
 import { IEquipmentModel } from '../Interfaces/IEquipmentModel';
 import { equipment, Equipment, NewEquipment } from '../../db/schemas/equipment';
 import { db } from '../../db/config/db_connect';
-import { eq } from 'drizzle-orm';
+import { and, eq, SQL } from 'drizzle-orm';
 
 export class EquipmentModel implements IEquipmentModel {
   async create(newEquipment: NewEquipment): Promise<Equipment> {
@@ -9,24 +9,24 @@ export class EquipmentModel implements IEquipmentModel {
     return createdEquipment[0];
   }
 
-  async delete(id: string): Promise<void> {
-    await db.delete(equipment).where(eq(equipment.id, id));
+  async delete(keys : SQL[]): Promise<void> {
+    await db.delete(equipment).where(and(...keys));
   }
 
   async getAll(): Promise<Equipment[]> {
     return db.select().from(equipment);
   }
 
-  async getById(id: string): Promise<Equipment | null> {
-    const resultEquipment = await db.select().from(equipment).where(eq(equipment.id, id)).limit(1);
+  async getById(keys : SQL[]): Promise<Equipment | null> {
+    const resultEquipment = await db.select().from(equipment).where(and(...keys)).limit(1);
     return resultEquipment[0];
   }
 
-  async update(id: string, equipmentData: Partial<Equipment>): Promise<Equipment | null> {
+  async update(keys : SQL[], equipmentData: Partial<Equipment>): Promise<Equipment | null> {
     const updatedEquipment = await db
       .update(equipment)
       .set(equipmentData)
-      .where(eq(equipment.id, id))
+      .where(and(...keys))
       .returning();
     return updatedEquipment[0];
   }

--- a/src/features/Equipment/utils.ts
+++ b/src/features/Equipment/utils.ts
@@ -1,4 +1,7 @@
 import z from 'zod';
+import { eq, SQL } from 'drizzle-orm';
+import { technician } from '../../db/schemas/technician';
+import { equipment } from '../../db/schemas/equipment';
 
 export const equipmentSchema = z.object({
   name: z.string().max(255),
@@ -6,3 +9,23 @@ export const equipmentSchema = z.object({
   state: z.string().max(255),
   id_department: z.string().uuid()
 });
+
+export type EquipmentQuery = {
+  id?: string;
+  name?: string;
+  type?: string;
+  state?: string;
+  id_department?: string;
+  acquisition_date? : string;
+}
+
+export function EquipmentQueryBuilder(query: EquipmentQuery) : SQL[] {
+  const filters : SQL[] = [];
+  if (query.id) filters.push(eq(equipment.id, query.id));
+  if (query.name) filters.push(eq(equipment.name, query.name));
+  if (query.type) filters.push(eq(equipment.type, query.type));
+  if (query.state) filters.push(eq(equipment, query.state));
+  if (query.id_department) filters.push(eq(equipment.id_department, query.id_department));
+  if (query.acquisition_date) filters.push(eq(equipment.acquisition_date, query.acquisition_date));
+  return filters;
+}

--- a/src/features/Interfaces/IEquipmentModel.ts
+++ b/src/features/Interfaces/IEquipmentModel.ts
@@ -1,13 +1,14 @@
 import { Equipment, NewEquipment } from '../../db/schemas/equipment';
+import { SQL } from 'drizzle-orm';
 
 export interface IEquipmentModel {
   create(newEquipment: NewEquipment): Promise<Equipment>;
 
   getAll(): Promise<Equipment[]>;
 
-  getById(id: string): Promise<Equipment | null>;
+  getById(keys : SQL[]): Promise<Equipment | null>;
 
-  update(id: string, equipmentData: Partial<Equipment>): Promise<Equipment | null>;
+  update(keys : SQL[], equipmentData: Partial<Equipment>): Promise<Equipment | null>;
 
-  delete(id: string): Promise<void>;
+  delete(keys : SQL[]): Promise<void>;
 }


### PR DESCRIPTION
This pull request includes several changes to the `Equipment` feature, focusing on improving the querying and handling of equipment data. The most important changes are the introduction of a query builder for filtering equipment data and updates to the model and controller to use this new query builder.

Improvements to querying equipment data:

* [`src/features/Equipment/utils.ts`](diffhunk://#diff-4468c7ebc25c11fd3d63f3ed87d5897af5eaf593d9fcc05208900eac6a9eda09R2-R31): Added `EquipmentQuery` type and `EquipmentQueryBuilder` function to build SQL filters based on equipment query parameters.

Updates to the equipment model:

* [`src/features/Equipment/model.ts`](diffhunk://#diff-87f13773ae143762b4217badb31b3508e6ba07530d449de8638524097ba8ce75L4-R29): Modified the methods `delete`, `getById`, and `update` to accept SQL filters instead of a single ID.
* [`src/features/Interfaces/IEquipmentModel.ts`](diffhunk://#diff-d12f1f006b57051e2385e7e0acbd6c0a8ced96f173bfa1b0049feb05aafea91aR2-R13): Updated the interface methods `getById`, `update`, and `delete` to use SQL filters.

Updates to the equipment controller:

* [`src/features/Equipment/controller.ts`](diffhunk://#diff-54a641290bb8f2e7d9809fa36e7de06615dad8d451c9f423a2ea148dceed88beL23): Updated the controller methods to use `EquipmentQueryBuilder` for building filters and removed the generation of random UUIDs for new equipment. [[1]](diffhunk://#diff-54a641290bb8f2e7d9809fa36e7de06615dad8d451c9f423a2ea148dceed88beL23) [[2]](diffhunk://#diff-54a641290bb8f2e7d9809fa36e7de06615dad8d451c9f423a2ea148dceed88beL45-R46) [[3]](diffhunk://#diff-54a641290bb8f2e7d9809fa36e7de06615dad8d451c9f423a2ea148dceed88beL64-R72) [[4]](diffhunk://#diff-54a641290bb8f2e7d9809fa36e7de06615dad8d451c9f423a2ea148dceed88beL79-R89)

Schema update:

* [`src/db/schemas/equipment.ts`](diffhunk://#diff-b8c6668cb56f53057ebe106687fa6724eb5d4b58a2cd3d7c62a81bad4b02f340L10-R10): Changed the `acquisition_date` column to use the string mode for timestamps.