### PR TITLE
removed ssl from local db connection

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     user: process.env.DB_USER || 'user',
     password: process.env.DB_PASSWORD || 'password',
     database: process.env.DB_NAME || 'dbname',
-    ssl: { rejectUnauthorized: false }
+    ssl: process.env.NODE_ENV === 'development-local' ? false : { rejectUnauthorized: false }
   }
 });

--- a/src/db/config/db_connect.ts
+++ b/src/db/config/db_connect.ts
@@ -10,7 +10,7 @@ const pool = new Pool({
   user: process.env.DB_USER || 'user',
   password: process.env.DB_PASSWORD || 'password',
   database: process.env.DB_NAME || 'dbname',
-  ssl: { rejectUnauthorized: false }
+  ssl: process.env.NODE_ENV === 'development-local' ? false : { rejectUnauthorized: false }
 });
 
 export const db = drizzle(pool, {


### PR DESCRIPTION
This pull request makes changes to the database configuration to handle SSL settings based on the environment. The updates ensure that SSL is not used in a local development environment but is enforced otherwise.

Changes to SSL configuration:

* [`drizzle.config.ts`](diffhunk://#diff-d4e1c765f5d43acb9c59d87b520418289031da3fe52f5031041502b1250509c8L32-R32): Updated the SSL setting to be conditional based on the `NODE_ENV` environment variable. If `NODE_ENV` is set to `development-local`, SSL is disabled; otherwise, SSL is enabled with `rejectUnauthorized: false`.
* [`src/db/config/db_connect.ts`](diffhunk://#diff-b1c4b7b457fd34dde441081c1ed934407f72a50f89606ebf3df7c8e694056028L13-R13): Made a similar change to the SSL setting as in `drizzle.config.ts`, ensuring consistency across the configuration files.