### PR TITLE
added interface IRepository

### DIFF
--- a/src/Interfaces/IDepartmentModel.ts
+++ b/src/Interfaces/IDepartmentModel.ts
@@ -1,14 +1,6 @@
 import { NewDepartment, Department } from '../features/Department/schema';
 import { DepartmentQuery } from '../features/Department/utils';
+import { IRepository } from './IRepository';
 
-export interface IDepartmentModel {
-  create(newDepartment: NewDepartment): Promise<Department>;
-
-  getAll(): Promise<Department[]>;
-
-  getById(keys: DepartmentQuery): Promise<Department | null>;
-
-  update(keys: DepartmentQuery, departmentData: Partial<Department>): Promise<Department | null>;
-
-  delete(keys: DepartmentQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface IDepartmentModel extends IRepository<DepartmentQuery, NewDepartment, Department> {}

--- a/src/Interfaces/IDowntimeModel.ts
+++ b/src/Interfaces/IDowntimeModel.ts
@@ -1,14 +1,6 @@
 import { Downtime, NewDowntime } from '../features/Downtime/schema';
 import { DowntimeQuery } from '../features/Downtime/utils';
+import { IRepository } from './IRepository';
 
-export interface IDowntimeModel {
-  create(newDowntime: NewDowntime): Promise<Downtime>;
-
-  getAll(): Promise<Downtime[]>;
-
-  getById(keys: DowntimeQuery): Promise<Downtime | null>;
-
-  update(keys: DowntimeQuery, userData: Partial<Downtime>): Promise<Downtime | null>;
-
-  delete(keys: DowntimeQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface IDowntimeModel extends IRepository<DowntimeQuery, NewDowntime, Downtime> {}

--- a/src/Interfaces/IEquipmentModel.ts
+++ b/src/Interfaces/IEquipmentModel.ts
@@ -1,14 +1,6 @@
 import { Equipment, NewEquipment } from '../features/Equipment/schema';
 import { EquipmentQuery } from '../features/Equipment/utils';
+import { IRepository } from './IRepository';
 
-export interface IEquipmentModel {
-  create(newEquipment: NewEquipment): Promise<Equipment>;
-
-  getAll(): Promise<Equipment[]>;
-
-  getById(keys: EquipmentQuery): Promise<Equipment | null>;
-
-  update(keys: EquipmentQuery, equipmentData: Partial<Equipment>): Promise<Equipment | null>;
-
-  delete(keys: EquipmentQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface IEquipmentModel extends IRepository<EquipmentQuery, NewEquipment, Equipment> {}

--- a/src/Interfaces/IMaintenanceModel.ts
+++ b/src/Interfaces/IMaintenanceModel.ts
@@ -1,17 +1,7 @@
 import { Maintenance, NewMaintenance } from '../features/Maintenance/schema';
 import { MaintenanceQuery } from '../features/Maintenance/utils';
+import { IRepository } from './IRepository';
 
-export interface IMaintenanceModel {
-  create(newMaintenance: NewMaintenance): Promise<Maintenance>;
-
-  getAll(): Promise<Maintenance[]>;
-
-  getById(keys: MaintenanceQuery): Promise<Maintenance | null>;
-
-  update(
-    keys: MaintenanceQuery,
-    maintenanceData: Partial<Maintenance>
-  ): Promise<Maintenance | null>;
-
-  delete(keys: MaintenanceQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface IMaintenanceModel
+  extends IRepository<MaintenanceQuery, NewMaintenance, Maintenance> {}

--- a/src/Interfaces/IRateModel.ts
+++ b/src/Interfaces/IRateModel.ts
@@ -1,14 +1,6 @@
 import { Rate, NewRate } from '../features/Rate/schema';
 import { RateQuery } from '../features/Rate/utils';
+import { IRepository } from './IRepository';
 
-export interface IRateModel {
-  create(newRate: NewRate): Promise<Rate>;
-
-  getAll(): Promise<Rate[]>;
-
-  getById(keys: RateQuery): Promise<Rate | null>;
-
-  update(keys: RateQuery, rateData: Partial<Rate>): Promise<Rate | null>;
-
-  delete(keys: RateQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface IRateModel extends IRepository<RateQuery, NewRate, Rate> {}

--- a/src/Interfaces/IRepository.ts
+++ b/src/Interfaces/IRepository.ts
@@ -1,0 +1,11 @@
+export interface IRepository<TQuery, TNew, T> {
+  create(newRate: TNew): Promise<T>;
+
+  getAll(): Promise<T[]>;
+
+  getById(keys: TQuery): Promise<T | null>;
+
+  update(keys: TQuery, rateData: Partial<T>): Promise<T | null>;
+
+  delete(keys: TQuery): Promise<void>;
+}

--- a/src/Interfaces/IRoleModel.ts
+++ b/src/Interfaces/IRoleModel.ts
@@ -1,14 +1,6 @@
 import { Role, NewRole } from '../features/Role/schema';
 import { RoleQuery } from '../features/Role/utils';
+import { IRepository } from './IRepository';
 
-export interface IRoleModel {
-  create(newRole: NewRole): Promise<Role>;
-
-  getAll(): Promise<Role[]>;
-
-  getById(keys: RoleQuery): Promise<Role | null>;
-
-  update(keys: RoleQuery, roleData: Partial<Role>): Promise<Role | null>;
-
-  delete(keys: RoleQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface IRoleModel extends IRepository<RoleQuery, NewRole, Role> {}

--- a/src/Interfaces/ITechnicianModel.ts
+++ b/src/Interfaces/ITechnicianModel.ts
@@ -1,14 +1,6 @@
 import { Technician, NewTechnician } from '../features/Technician/schema';
 import { TechnicianQuery } from '../features/Technician/utils';
+import { IRepository } from './IRepository';
 
-export interface ITechnicianModel {
-  create(newTechnician: NewTechnician): Promise<Technician>;
-
-  getAll(): Promise<Technician[]>;
-
-  getById(keys: TechnicianQuery): Promise<Technician | null>;
-
-  update(keys: TechnicianQuery, technicianData: Partial<Technician>): Promise<Technician | null>;
-
-  delete(keys: TechnicianQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface ITechnicianModel extends IRepository<TechnicianQuery, NewTechnician, Technician> {}

--- a/src/Interfaces/ITransferModel.ts
+++ b/src/Interfaces/ITransferModel.ts
@@ -1,14 +1,6 @@
 import { Transfer, NewTransfer } from '../features/Transfer/schema';
 import { TransferQuery } from '../features/Transfer/utils';
+import { IRepository } from './IRepository';
 
-export interface ITransferModel {
-  create(newTransfer: NewTransfer): Promise<Transfer>;
-
-  getAll(): Promise<Transfer[]>;
-
-  getById(keys: TransferQuery): Promise<Transfer | null>;
-
-  update(keys: TransferQuery, transferData: Partial<Transfer>): Promise<Transfer | null>;
-
-  delete(keys: TransferQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface ITransferModel extends IRepository<TransferQuery, NewTransfer, Transfer> {}

--- a/src/Interfaces/IUserModel.ts
+++ b/src/Interfaces/IUserModel.ts
@@ -1,14 +1,6 @@
 import { User, NewUser } from '../features/User/schema';
 import { UserQuery } from '../features/User/utils';
+import { IRepository } from './IRepository';
 
-export interface IUserModel {
-  create(newUser: NewUser): Promise<User>;
-
-  getAll(): Promise<User[]>;
-
-  getById(keys: UserQuery): Promise<User | null>;
-
-  update(keys: UserQuery, userData: Partial<User>): Promise<User | null>;
-
-  delete(keys: UserQuery): Promise<void>;
-}
+// eslint-disable-next-line
+export interface IUserModel extends IRepository<UserQuery, NewUser, User> {}


### PR DESCRIPTION
This pull request refactors multiple model interfaces to extend a common repository interface, `IRepository`, to reduce code duplication and improve maintainability. The most important changes include the creation of the `IRepository` interface and the modification of several model interfaces to extend this new interface.

Creation of common repository interface:

* [`src/Interfaces/IRepository.ts`](diffhunk://#diff-dd118a0042fcd42a7153a09b6c7fe8f2dbcbaa5cb129168a9fa6e7c7d801a80dR1-R11): Added the `IRepository` interface which defines common CRUD operations for various models.

Refactoring model interfaces to extend the common repository interface:

* [`src/Interfaces/IDepartmentModel.ts`](diffhunk://#diff-73b8576390b874120dd047b7eaf77e024ce2c99e3df6afd2c1f4e8148c15422fR3-R6): Modified the `IDepartmentModel` interface to extend `IRepository` for `DepartmentQuery`, `NewDepartment`, and `Department`.
* [`src/Interfaces/IDowntimeModel.ts`](diffhunk://#diff-2732743c0234eb45812bf21de6ce572071df4424dba413eadb46de7565f35fb5R3-R6): Modified the `IDowntimeModel` interface to extend `IRepository` for `DowntimeQuery`, `NewDowntime`, and `Downtime`.
* [`src/Interfaces/IEquipmentModel.ts`](diffhunk://#diff-e42ced7b98b216b509ca726fde69b55ec11b9fa1911d61c85a7419d148fe003eR3-R6): Modified the `IEquipmentModel` interface to extend `IRepository` for `EquipmentQuery`, `NewEquipment`, and `Equipment`.
* [`src/Interfaces/IMaintenanceModel.ts`](diffhunk://#diff-1f45e5c771f75f027d93aa30f808e260257385ce03f1d38c4041e912a9b575d5R3-R7): Modified the `IMaintenanceModel` interface to extend `IRepository` for `MaintenanceQuery`, `NewMaintenance`, and `Maintenance`.

Other model interfaces were similarly refactored to extend the `IRepository` interface, ensuring consistency and reducing redundancy across the codebase.