### PR TITLE
updating testing and swagger

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -179,7 +179,9 @@ const config: Config = {
 
   // Whether to use watchman for file crawling
   // watchman: true,
-  preset: 'ts-jest' // Usa ts-jest como transformador predeterminado
+  preset: 'ts-jest', // Usa ts-jest como transformador predeterminado
+
+  testTimeout: 30000
 };
 
 export default config;

--- a/src/features/Department/router.ts
+++ b/src/features/Department/router.ts
@@ -145,9 +145,6 @@ import { DepartmentController } from './controller';
  *         name:
  *           type: string
  *           description: Name of the department.
- *         description:
- *           type: string
- *           description: Description of the department.
  */
 
 export const departmentRouter = (departmentModel: IDepartmentModel) => {

--- a/src/features/Department/test/department.test.ts
+++ b/src/features/Department/test/department.test.ts
@@ -14,9 +14,7 @@ describe('Department CRUD', () => {
   let departmentId = '';
 
   it('should create a new department', async () => {
-    const response = await request(app)
-      .post('/api/department')
-      .send({ name: 'Cardiology', description: 'Cardiology Department' });
+    const response = await request(app).post('/api/department').send({ name: 'Cardiology' });
     expect(response.status).toEqual(200);
     departmentId = response.body.id;
   });

--- a/src/features/Downtime/router.ts
+++ b/src/features/Downtime/router.ts
@@ -241,6 +241,12 @@ import { DowntimeController } from './controller';
  *         id_dep_receiver:
  *           type: string
  *           description: ID of the department receiver.
+ *         status:
+ *           type: string
+ *           description: Status of the downtime.
+ *         cause:
+ *          type: string
+ *          description: Cause of the downtime.
  */
 
 export const downtimeRouter = (downtimeModel: IDowntimeModel) => {

--- a/src/features/Downtime/test/downtime.test.ts
+++ b/src/features/Downtime/test/downtime.test.ts
@@ -17,23 +17,20 @@ describe('Downtime CRUD', () => {
   let id_dep_receiver = '';
   let date = '';
   it('should create a new downtime', async () => {
-    const response = await request(app)
-      .post('/api/downtime')
-      //envia diego recibe mauricio en BD
-      .send({
-        id_sender: '0733d98f-63b0-405f-8775-26a870c1f434',
-        id_receiver: '1ab7ef42-c6f4-45d6-b9e5-aa1f8fd39e3c',
-        id_equipment: '0a87207a-3486-445b-97eb-65d14fda2249',
-        id_dep_receiver: '76b53f41-c7fb-4048-a076-2cbb0ff60fc6',
-        status: 'active',
-        cause: 'Maintenance'
-      });
+    const response = await request(app).post('/api/downtime').send({
+      id_sender: 'add0921a-6979-46a3-a070-5f41a9ac08f7',
+      id_receiver: 'e1eb14d6-0750-41f8-975b-316b9dbc1a4d',
+      id_equipment: 'a3739594-c850-4669-9c5f-5b43d1253507',
+      id_dep_receiver: '18412513-0ac2-41ef-b1bf-826d0acb4952',
+      status: 'active',
+      cause: 'Maintenance'
+    });
     expect(response.status).toEqual(201);
 
-    id_sender = response.body.id_sender;
-    id_reciever = response.body.id_receiver;
-    id_equipment = response.body.id_equipment;
-    id_dep_receiver = response.body.id_dep_receiver;
+    id_sender = response.body.sender.id;
+    id_reciever = response.body.receiver.id;
+    id_equipment = response.body.equipment.id;
+    id_dep_receiver = response.body.dep_receiver.id;
     date = response.body.date;
   });
 

--- a/src/features/Equipment/router.ts
+++ b/src/features/Equipment/router.ts
@@ -144,9 +144,13 @@ import { EquipmentController } from './controller';
  *         type:
  *           type: string
  *           description: Type of the equipment.
- *         status:
+ *         state:
  *           type: string
  *           description: Status of the equipment.
+ *         id_department:
+ *           type: string
+ *           description: ID of the department.
+ *
  */
 export const equipmentRouter = (equipmentModel: IEquipmentModel) => {
   const router = Router();

--- a/src/features/Equipment/test/equipment.test.ts
+++ b/src/features/Equipment/test/equipment.test.ts
@@ -18,7 +18,7 @@ describe('Equipment CRUD', () => {
       name: 'High resolution X-Ray machine',
       type: 'X-ray Machine',
       state: 'active',
-      id_department: '1c5e96e4-f66b-4cdc-95ae-5c0c07a41340'
+      id_department: '24cc863c-2969-49a3-ac60-8db75a3d3b35'
     });
     expect(response.status).toEqual(201);
     equipmentId = response.body.id;

--- a/src/features/Maintenance/router.ts
+++ b/src/features/Maintenance/router.ts
@@ -199,9 +199,12 @@ import { MaintenanceController } from './controller';
  *           type: string
  *           format: date
  *           description: Date of the maintenance.
- *         details:
- *           type: string
- *           description: Details of the maintenance.
+ *         cost:
+ *           type: number
+ *           description: Cost of the maintenance.
+ *         type:
+ *            type: string
+ *            description: Type of maintenance.
  */
 export const maintenanceRouter = (maintenanceModel: IMaintenanceModel) => {
   const router = Router();

--- a/src/features/Maintenance/test/maintenance.test.ts
+++ b/src/features/Maintenance/test/maintenance.test.ts
@@ -16,14 +16,14 @@ describe('Maintenance CRUD', () => {
   let date = '';
   it('should create a new maintenance', async () => {
     const response = await request(app).post('/api/maintenance').send({
-      id_technician: '61860cce-cd6f-4e07-8db3-37527e32e671',
+      id_technician: 'add0921a-6979-46a3-a070-5f41a9ac08f7',
       type: 'Scheduled',
       cost: 12,
-      id_equipment: '0a87207a-3486-445b-97eb-65d14fda2249'
+      id_equipment: 'a3739594-c850-4669-9c5f-5b43d1253507'
     });
     expect(response.status).toEqual(201);
-    id_equipment = response.body.id_equipment;
-    id_technician = response.body.id_technician;
+    id_equipment = response.body.equipment.id;
+    id_technician = response.body.technician.id;
     date = response.body.date;
   });
 

--- a/src/features/Rate/router.ts
+++ b/src/features/Rate/router.ts
@@ -198,10 +198,10 @@ import { RateController } from './controller';
  *           type: string
  *           format: date
  *           description: Date of the rate.
- *         rating:
+ *         score:
  *           type: number
  *           description: Rating value.
- *         comments:
+ *         comment:
  *           type: string
  *           description: Comments about the rate.
  */

--- a/src/features/Rate/test/rate.test.ts
+++ b/src/features/Rate/test/rate.test.ts
@@ -16,14 +16,14 @@ describe('Rate CRUD', () => {
   let date = '';
   it('should create a new rate', async () => {
     const response = await request(app).post('/api/rate').send({
-      id_technician: '61860cce-cd6f-4e07-8db3-37527e32e671',
-      id_user: '0733d98f-63b0-405f-8775-26a870c1f434',
+      id_technician: 'add0921a-6979-46a3-a070-5f41a9ac08f7',
+      id_user: '84732729-8c92-4067-9912-9f6743920bb3',
       score: 5,
       comment: 'Excellent service'
     });
     expect(response.status).toEqual(200);
-    id_technician = response.body.id_technician;
-    id_user = response.body.id_user;
+    id_technician = response.body.technician.id;
+    id_user = response.body.user.id;
     date = response.body.date;
   });
 

--- a/src/features/Role/router.ts
+++ b/src/features/Role/router.ts
@@ -156,11 +156,6 @@ import { RoleController } from './controller';
  *         name:
  *           type: string
  *           description: Name of the role.
- *         permissions:
- *           type: array
- *           items:
- *             type: string
- *           description: List of permissions assigned to the role.
  */
 
 export const roleRouter = (roleModel: IRoleModel) => {

--- a/src/features/Technician/router.ts
+++ b/src/features/Technician/router.ts
@@ -151,15 +151,15 @@ import { TechnicianController } from './controller';
  *     Technician:
  *       type: object
  *       properties:
- *         id:
+ *         id_user:
  *           type: string
  *           description: ID of the technician.
- *         name:
+ *         exp_year:
  *           type: string
- *           description: Name of the technician.
- *         department:
+ *           description: Experience of the technician.
+ *         specialty:
  *           type: string
- *           description: Department of the technician.
+ *           description: Specialty of the technician.
  */
 export const technicianRouter = (technicianModel: ITechnicianModel, userModel: IUserModel) => {
   const router = Router();

--- a/src/features/Technician/test/technician.test.ts
+++ b/src/features/Technician/test/technician.test.ts
@@ -12,12 +12,17 @@ app.use('/api', appRouter(appModels));
 
 describe('Technician CRUD', () => {
   let id_user = '';
+
   it('should create a new technician', async () => {
     const response = await request(app)
       .post('/api/technician')
-      .send({ id_user: '57b6e269-9221-4474-a3cb-1576749a80a0', exp_years: 2, specialty: 'obrero' });
+      .send({
+        id_user: '41893260-aaf4-4339-ac97-39019b6c2343',
+        exp_years: 2,
+        specialty: 'panadero'
+      });
     expect(response.status).toEqual(201);
-    id_user = response.body.id_user;
+    id_user = response.body.id;
   });
 
   it('should get all technicians', async () => {

--- a/src/features/Transfer/router.ts
+++ b/src/features/Transfer/router.ts
@@ -296,6 +296,9 @@ import { TransferController } from './controller';
  *         id_receiver_dep:
  *           type: string
  *           description: ID of the receiver department.
+ *         downtime_status:
+ *           type: string
+ *           description: Status of the downtime.
  */
 
 export const transferRouter = (transferModel: ITransferModel) => {

--- a/src/features/Transfer/test/transfer.test.ts
+++ b/src/features/Transfer/test/transfer.test.ts
@@ -19,20 +19,20 @@ describe('Transfer CRUD', () => {
   let date = '';
   it('should create a new transfer', async () => {
     const response = await request(app).post('/api/transfer').send({
-      id_sender: '0733d98f-63b0-405f-8775-26a870c1f434',
-      id_receiver: '1ab7ef42-c6f4-45d6-b9e5-aa1f8fd39e3c',
-      id_equipment: '0a87207a-3486-445b-97eb-65d14fda2249',
-      id_origin_dep: '1c5e96e4-f66b-4cdc-95ae-5c0c07a41340',
-      id_receiver_dep: '76b53f41-c7fb-4048-a076-2cbb0ff60fc6',
+      id_sender: 'add0921a-6979-46a3-a070-5f41a9ac08f7',
+      id_receiver: 'e1eb14d6-0750-41f8-975b-316b9dbc1a4d',
+      id_equipment: 'a3739594-c850-4669-9c5f-5b43d1253507',
+      id_origin_dep: '95262fb4-44fb-46d3-bf08-540c0f16b9c7',
+      id_receiver_dep: '18412513-0ac2-41ef-b1bf-826d0acb4952',
       downtime_status: 'active'
     });
     expect(response.status).toEqual(201);
 
-    id_sender = response.body.id_sender;
-    id_receiver = response.body.id_receiver;
-    id_equipment = response.body.id_equipment;
-    id_origin_dep = response.body.id_origin_dep;
-    id_receiver_dep = response.body.id_receiver_dep;
+    id_sender = response.body.sender.id;
+    id_receiver = response.body.receiver.id;
+    id_equipment = response.body.equipment.id;
+    id_origin_dep = response.body.origin_dep.id;
+    id_receiver_dep = response.body.receiver_dep.id;
     date = response.body.date;
   });
 

--- a/src/features/User/test/user.test.ts
+++ b/src/features/User/test/user.test.ts
@@ -16,10 +16,10 @@ describe('User CRUD', () => {
 
   it('should create a new user', async () => {
     const response = await request(app).post('/api/user').send({
-      name: 'Diego Doe',
-      password: 'Candela',
-      id_role: 1,
-      id_department: '1c5e96e4-f66b-4cdc-95ae-5c0c07a41340'
+      name: 'roberto',
+      password: 'revolucionario2025',
+      id_role: 2,
+      id_department: '24cc863c-2969-49a3-ac60-8db75a3d3b35'
     });
     expect(response.status).toEqual(201);
     userId = response.body.id;


### PR DESCRIPTION
This pull request includes several changes across different features to update and improve the codebase, mainly focusing on modifying API endpoints and test cases. The most important changes include adding new fields to the API endpoints, updating test cases to match the new data structures, and removing or renaming certain fields for consistency.

### API Endpoint Updates:

* [`src/features/Downtime/router.ts`](diffhunk://#diff-9abd7224c971e4c8eced4390084f6e3afe4d01ca7bab6ff8cb86fc4ac0332fcdR244-R249): Added `status` and `cause` fields to the downtime endpoint.
* [`src/features/Equipment/router.ts`](diffhunk://#diff-c838cf1c9ba564346321bf3e799fbc764f49376f5e62fd8c40587ee0e6bff041L147-R153): Renamed `status` to `state` and added `id_department` field to the equipment endpoint.
* [`src/features/Maintenance/router.ts`](diffhunk://#diff-fb81ee1156ae4409cf312814dd91e750e0431987464f5e2ecd2128566eac5b80L202-R207): Added `cost` field and renamed `details` to `type` in the maintenance endpoint.
* [`src/features/Rate/router.ts`](diffhunk://#diff-342015eff75cc738ccc8e67bafd07af788f8a2afaedc8176effca9b615a86bc5L201-R204): Renamed `rating` to `score` and `comments` to `comment` in the rate endpoint.
* [`src/features/Transfer/router.ts`](diffhunk://#diff-33d4371237a3cc11e69d8b4953c7a5736052d23d3990278954395b1820f8ccc1R299-R301): Added `downtime_status` field to the transfer endpoint.

### Test Case Updates:

* [`src/features/Department/test/department.test.ts`](diffhunk://#diff-567b1cafac2b94eacf63bc731078e139817e6ce9d72cf581d07a9400add4ffa5L17-R17): Removed `description` field from the department creation test.
* [`src/features/Downtime/test/downtime.test.ts`](diffhunk://#diff-e0ff5b511be1cb92aca3fa8fc72f51c1ac4ecd65ddeba05fb1a25fb1cbcbe9bfL20-R33): Updated downtime creation test to include new `status` and `cause` fields.
* [`src/features/Equipment/test/equipment.test.ts`](diffhunk://#diff-277bde8b29eda1a574b553c95f7384787d4e6b8d57277f50be468eb11d98d07aL21-R21): Updated `id_department` value in the equipment creation test.
* [`src/features/Maintenance/test/maintenance.test.ts`](diffhunk://#diff-8bd452c7079f799e60d4cc5f106cdb98290d7b206fee9ed9a0d7ed4f610012b0L19-R26): Updated maintenance creation test to include new `cost` field and renamed fields.
* [`src/features/Rate/test/rate.test.ts`](diffhunk://#diff-97e1b7754d97b0e41ce8cb948a7186e7cfd1f2e5ac16f30413da6b395bc33fd0L19-R26): Updated rate creation test to use new `score` and `comment` fields.
* [`src/features/Technician/test/technician.test.ts`](diffhunk://#diff-3b1e0e7ff831986ed883ab803f9e43ca85a069b860b744ee22289f593af8db86R15-R25): Updated technician creation test to use new field names and values.
* [`src/features/Transfer/test/transfer.test.ts`](diffhunk://#diff-691459b6749ea5574d3d30a8282ca1034af3133e21620ab27b55ecd4e78fd131L22-R35): Updated transfer creation test to include new `downtime_status` field and updated field names.
* [`src/features/User/test/user.test.ts`](diffhunk://#diff-e13454dc873b97b31fa0f2cecdac66ca27bbbe73959136bb651630e6b22d13b6L19-R22): Updated user creation test with new values for fields.

### Configuration Updates:

* [`jest.config.ts`](diffhunk://#diff-860bd1f15d1e0bafcfc6f62560524f588e6d6bf56d4ab1b0f6f8146461558730L182-R184): Added `testTimeout` configuration to set the timeout for tests to 30000 milliseconds.