### PR TITLE
added enums to schemas equipment maintenance rate and  transfer

### DIFF
--- a/src/features/Equipment/utils.ts
+++ b/src/features/Equipment/utils.ts
@@ -2,10 +2,19 @@ import z from 'zod';
 import { eq, SQL } from 'drizzle-orm';
 import { equipment } from './schema';
 
+const equipmentState = z.enum(['Operativo', 'Mantenimiento', 'Baja']);
+const equipmentType = z.enum([
+  'Informático',
+  'Comunicaciones',
+  'Electrónico',
+  'Seguridad',
+  'Oficina'
+]);
+
 export const equipmentSchema = z.object({
   name: z.string().max(255),
-  type: z.string().max(255),
-  state: z.string().max(255),
+  type: equipmentType,
+  state: equipmentState,
   id_department: z.string().uuid()
 });
 

--- a/src/features/Maintenance/utils.ts
+++ b/src/features/Maintenance/utils.ts
@@ -2,11 +2,13 @@ import z from 'zod';
 import { eq, SQL } from 'drizzle-orm';
 import { maintenance } from './schema';
 
+const maintenanceType = z.enum(['Preventivo', 'Correctivo', 'Predictivo']);
+
 export const maintenanceSchema = z.object({
   id_technician: z.string().uuid(),
   id_equipment: z.string().uuid(),
-  type: z.string(),
-  cost: z.number()
+  type: maintenanceType,
+  cost: z.number().positive()
 });
 
 export type MaintenanceQuery = {

--- a/src/features/Rate/utils.ts
+++ b/src/features/Rate/utils.ts
@@ -6,7 +6,7 @@ export const rateSchema = z.object({
   id_technician: z.string().uuid(),
   id_user: z.string().uuid(),
   comment: z.string(),
-  score: z.number()
+  score: z.number().min(1).max(5)
 });
 
 export type RateQuery = {

--- a/src/features/Transfer/utils.ts
+++ b/src/features/Transfer/utils.ts
@@ -2,13 +2,15 @@ import z from 'zod';
 import { eq, SQL } from 'drizzle-orm';
 import { transfer } from './schema';
 
+const transferStatus = z.enum(['Pendiente', 'Completado', 'Aprobado', 'Cancelado']);
+
 export const transferSchema = z.object({
   id_sender: z.string().uuid(),
   id_receiver: z.string().uuid(),
   id_equipment: z.string().uuid(),
   id_origin_dep: z.string().uuid(),
   id_receiver_dep: z.string().uuid(),
-  downtime_status: z.string()
+  downtime_status: transferStatus
 });
 
 export type TransferQuery = {


### PR DESCRIPTION
This pull request introduces several schema improvements across different feature modules to enhance data validation and consistency. The most important changes include the introduction of enumerations for specific fields and the addition of constraints on numeric fields.

Schema improvements:

* [`src/features/Equipment/utils.ts`](diffhunk://#diff-4468c7ebc25c11fd3d63f3ed87d5897af5eaf593d9fcc05208900eac6a9eda09R5-R17): Added `equipmentState` and `equipmentType` enumerations for the `state` and `type` fields in the `equipmentSchema`.
* [`src/features/Maintenance/utils.ts`](diffhunk://#diff-0915d599ca21796612fafbe803a12b87621f8cdc7a017bcb99aeb1a4b82f94f4R5-R11): Introduced `maintenanceType` enumeration for the `type` field and added a positive constraint to the `cost` field in the `maintenanceSchema`.
* [`src/features/Rate/utils.ts`](diffhunk://#diff-39a7841ee2d756bf9339ecb042e41c7fe3d8ae82925417c7d9988f409f94df24L9-R9): Added a constraint to the `score` field to ensure it is between 1 and 5 in the `rateSchema`.
* [`src/features/Transfer/utils.ts`](diffhunk://#diff-079279e69a8d19a4c44a2a370c9629aeee7e1a358f7f91ef7222c9bb69797e60R5-R13): Introduced `transferStatus` enumeration for the `downtime_status` field in the `transferSchema`.