### PR TITLE
Refactor enums

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,1 +1,27 @@
+export const DowntimeStatuses: [string, ...string[]] = [
+  'Pendiente de evaluación',
+  'Retirado del servicio',
+  'Reutilizado',
+  'Baja Definitiva'
+];
+
+export const EquipmentStatuses: [string, ...string[]] = ['Operativo', 'Mantenimiento', 'Baja'];
+
+export const EquipmentTypes: [string, ...string[]] = [
+  'Informático',
+  'Comunicaciones',
+  'Electrónico',
+  'Seguridad',
+  'Oficina'
+];
+
+export const TransferStatuses: [string, ...string[]] = [
+  'Pendiente',
+  'Completado',
+  'Aprobado',
+  'Cancelado'
+];
+
+export const MaintenanceTypes: [string, ...string[]] = ['Preventivo', 'Correctivo', 'Predictivo'];
+
 export const Roles: [string, ...string[]] = ['Administrador', 'Técnico', 'Jefe de sección'];

--- a/src/features/Downtime/schema.ts
+++ b/src/features/Downtime/schema.ts
@@ -1,7 +1,10 @@
-import { pgTable, uuid, timestamp, varchar, primaryKey } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, timestamp, varchar, primaryKey, pgEnum } from 'drizzle-orm/pg-core';
 import { user } from '../User/schema';
 import { equipment } from '../Equipment/schema';
 import { department } from '../Department/schema';
+import { DowntimeStatuses } from '../../enums';
+
+const status = pgEnum('downtimeStatus', DowntimeStatuses);
 
 export const downtime = pgTable(
   'downtime',
@@ -19,7 +22,7 @@ export const downtime = pgTable(
     id_dep_receiver: uuid('id_dep_receiver')
       .notNull()
       .references(() => department.id),
-    status: varchar('status', { length: 255 }).notNull(), // Define as enum later
+    status: status().notNull(),
     cause: varchar('cause', { length: 255 }).notNull()
   },
   (table) => {

--- a/src/features/Downtime/utils.ts
+++ b/src/features/Downtime/utils.ts
@@ -1,13 +1,9 @@
 import z from 'zod';
 import { eq, SQL } from 'drizzle-orm';
 import { downtime } from './schema';
+import { DowntimeStatuses } from '../../enums';
 
-const downtimeStatus = z.enum([
-  'Pendiente de evaluación',
-  'Retirado del servicio',
-  'Reutilizado',
-  'Baja Definitiva'
-]);
+const downtimeStatus = z.enum(DowntimeStatuses);
 
 export const downtimeSchema = z.object({
   id_sender: z.string().uuid(),

--- a/src/features/Equipment/schema.ts
+++ b/src/features/Equipment/schema.ts
@@ -1,11 +1,15 @@
-import { pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+import { pgEnum, pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 import { department } from '../Department/schema';
+import { EquipmentStatuses, EquipmentTypes } from '../../enums';
+
+const type = pgEnum('equipmentType', EquipmentTypes);
+const status = pgEnum('equipmentState', EquipmentStatuses);
 
 export const equipment = pgTable('equipment', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: varchar('name', { length: 255 }).notNull(),
-  type: varchar('type', { length: 255 }).notNull(),
-  state: varchar('state', { length: 255 }).notNull(),
+  type: type().notNull(),
+  status: status().notNull(),
   id_department: uuid('id_department')
     .notNull()
     .references(() => department.id),

--- a/src/features/Equipment/types.ts
+++ b/src/features/Equipment/types.ts
@@ -6,7 +6,7 @@ export interface EquipmentType {
   id: string;
   name: string;
   type: string;
-  state: string;
+  status: string;
   department: DepartmentType;
   acquisition_date: string;
 }
@@ -15,7 +15,7 @@ export const equipmentSelection = {
   id: equipment.id,
   name: equipment.name,
   type: equipment.type,
-  state: equipment.state,
+  status: equipment.status,
   department: {
     id: equipment.id_department,
     name: department.name

--- a/src/features/Equipment/utils.ts
+++ b/src/features/Equipment/utils.ts
@@ -1,20 +1,15 @@
 import z from 'zod';
 import { eq, SQL } from 'drizzle-orm';
 import { equipment } from './schema';
+import { EquipmentStatuses, EquipmentTypes } from '../../enums';
 
-const equipmentState = z.enum(['Operativo', 'Mantenimiento', 'Baja']);
-const equipmentType = z.enum([
-  'Informático',
-  'Comunicaciones',
-  'Electrónico',
-  'Seguridad',
-  'Oficina'
-]);
+const equipmentState = z.enum(EquipmentStatuses);
+const equipmentType = z.enum(EquipmentTypes);
 
 export const equipmentSchema = z.object({
   name: z.string().max(255),
   type: equipmentType,
-  state: equipmentState,
+  status: equipmentState,
   id_department: z.string().uuid()
 });
 

--- a/src/features/Maintenance/schema.ts
+++ b/src/features/Maintenance/schema.ts
@@ -1,6 +1,9 @@
-import { pgTable, uuid, timestamp, varchar, real, primaryKey } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, timestamp, real, primaryKey, pgEnum } from 'drizzle-orm/pg-core';
 import { technician } from '../Technician/schema';
 import { equipment } from '../Equipment/schema';
+import { MaintenanceTypes } from '../../enums';
+
+const type = pgEnum('maintenanceType', MaintenanceTypes);
 
 export const maintenance = pgTable(
   'maintenance',
@@ -12,7 +15,7 @@ export const maintenance = pgTable(
       .notNull()
       .references(() => equipment.id),
     date: timestamp('date', { mode: 'string' }).notNull().defaultNow(),
-    type: varchar('type', { length: 255 }).notNull(),
+    type: type().notNull(),
     cost: real('cost').notNull()
   },
   (table) => {

--- a/src/features/Maintenance/utils.ts
+++ b/src/features/Maintenance/utils.ts
@@ -1,8 +1,9 @@
 import z from 'zod';
 import { eq, SQL } from 'drizzle-orm';
 import { maintenance } from './schema';
+import { MaintenanceTypes } from '../../enums';
 
-const maintenanceType = z.enum(['Preventivo', 'Correctivo', 'Predictivo']);
+const maintenanceType = z.enum(MaintenanceTypes);
 
 export const maintenanceSchema = z.object({
   id_technician: z.string().uuid(),

--- a/src/features/Transfer/schema.ts
+++ b/src/features/Transfer/schema.ts
@@ -1,7 +1,10 @@
-import { pgTable, uuid, timestamp, varchar, primaryKey } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, timestamp, primaryKey, pgEnum } from 'drizzle-orm/pg-core';
 import { user } from '../User/schema';
 import { equipment } from '../Equipment/schema';
 import { department } from '../Department/schema';
+import { TransferStatuses } from '../../enums';
+
+const status = pgEnum('statuses', TransferStatuses);
 
 export const transfer = pgTable(
   'transfer',
@@ -22,7 +25,7 @@ export const transfer = pgTable(
     id_receiver_dep: uuid('id_receiver_dep')
       .notNull()
       .references(() => department.id),
-    downtime_status: varchar('downtime_status', { length: 255 }).notNull() //TODO Define as enum later
+    status: status().notNull()
   },
   (table) => {
     return {

--- a/src/features/Transfer/types.ts
+++ b/src/features/Transfer/types.ts
@@ -35,5 +35,5 @@ export const transferSelection = {
     id: alias(department, 'receiver_dep').id,
     name: alias(department, 'receiver_dep').name
   },
-  status: transfer.downtime_status
+  status: transfer.status
 };

--- a/src/features/Transfer/utils.ts
+++ b/src/features/Transfer/utils.ts
@@ -1,8 +1,9 @@
 import z from 'zod';
 import { eq, SQL } from 'drizzle-orm';
 import { transfer } from './schema';
+import { TransferStatuses } from '../../enums';
 
-const transferStatus = z.enum(['Pendiente', 'Completado', 'Aprobado', 'Cancelado']);
+const transferStatus = z.enum(TransferStatuses);
 
 export const transferSchema = z.object({
   id_sender: z.string().uuid(),
@@ -10,7 +11,7 @@ export const transferSchema = z.object({
   id_equipment: z.string().uuid(),
   id_origin_dep: z.string().uuid(),
   id_receiver_dep: z.string().uuid(),
-  downtime_status: transferStatus
+  status: transferStatus
 });
 
 export type TransferQuery = {
@@ -20,7 +21,7 @@ export type TransferQuery = {
   date?: string;
   id_origin_dep?: string;
   id_receiver_dep?: string;
-  downtime_status?: string;
+  status?: string;
 };
 
 export function TransferQueryBuilder(query: TransferQuery): SQL[] {
@@ -31,6 +32,6 @@ export function TransferQueryBuilder(query: TransferQuery): SQL[] {
   if (query.date) filters.push(eq(transfer.date, query.date));
   if (query.id_origin_dep) filters.push(eq(transfer.id_origin_dep, query.id_origin_dep));
   if (query.id_receiver_dep) filters.push(eq(transfer.id_receiver_dep, query.id_receiver_dep));
-  if (query.downtime_status) filters.push(eq(transfer.downtime_status, query.downtime_status));
+  if (query.status) filters.push(eq(transfer.status, query.status));
   return filters;
 }


### PR DESCRIPTION
This pull request includes several changes to standardize the use of enums across different schemas and utilities in the project. The most important changes involve defining enums in a centralized file and updating the schema and utility files to use these enums.

### Standardization of Enums:

* [`src/enums.ts`](diffhunk://#diff-00310f3f832445de900d07b99183266cabc84aa21246ec7f1d136635b3108f79R1-R25): Added centralized enums for `DowntimeStatuses`, `EquipmentStatuses`, `EquipmentTypes`, `TransferStatuses`, and `MaintenanceTypes`.

### Schema Updates:

* [`src/features/Downtime/schema.ts`](diffhunk://#diff-d8f86fbdb0fc2c6ab8f1a83116a2f02143fb4a65bc36a17941b276462ebf5226L1-R7): Imported `DowntimeStatuses` from `enums.ts` and updated the `status` field to use the `pgEnum` type. [[1]](diffhunk://#diff-d8f86fbdb0fc2c6ab8f1a83116a2f02143fb4a65bc36a17941b276462ebf5226L1-R7) [[2]](diffhunk://#diff-d8f86fbdb0fc2c6ab8f1a83116a2f02143fb4a65bc36a17941b276462ebf5226L22-R25)
* [`src/features/Equipment/schema.ts`](diffhunk://#diff-423989d60c82e764773d7612d234a29aedcded70c457a5ded83d1d2fe3a21244L1-R12): Imported `EquipmentStatuses` and `EquipmentTypes` from `enums.ts` and updated the `type` and `status` fields to use the `pgEnum` type.
* [`src/features/Maintenance/schema.ts`](diffhunk://#diff-4f76dab2a529920bdaa96ed7c19da6d937ccf6f96f5e14817760d331f474e8dcL1-R6): Imported `MaintenanceTypes` from `enums.ts` and updated the `type` field to use the `pgEnum` type. [[1]](diffhunk://#diff-4f76dab2a529920bdaa96ed7c19da6d937ccf6f96f5e14817760d331f474e8dcL1-R6) [[2]](diffhunk://#diff-4f76dab2a529920bdaa96ed7c19da6d937ccf6f96f5e14817760d331f474e8dcL15-R18)
* [`src/features/Transfer/schema.ts`](diffhunk://#diff-95261da1935f76f70709ad47419f31f8b464cdc170ce3abba9d4284be3f4d8f1L1-R7): Imported `TransferStatuses` from `enums.ts` and updated the `status` field to use the `pgEnum` type. [[1]](diffhunk://#diff-95261da1935f76f70709ad47419f31f8b464cdc170ce3abba9d4284be3f4d8f1L1-R7) [[2]](diffhunk://#diff-95261da1935f76f70709ad47419f31f8b464cdc170ce3abba9d4284be3f4d8f1L25-R28)

### Utility Updates:

* [`src/features/Downtime/utils.ts`](diffhunk://#diff-300fa5008de02cc1634ccd9330b31ff7d47f65e27de56f8e976659792fb9a536R4-R6): Updated the `downtimeStatus` to use the `DowntimeStatuses` enum from `enums.ts`.
* [`src/features/Equipment/utils.ts`](diffhunk://#diff-4468c7ebc25c11fd3d63f3ed87d5897af5eaf593d9fcc05208900eac6a9eda09R4-R12): Updated the `equipmentState` and `equipmentType` to use the `EquipmentStatuses` and `EquipmentTypes` enums from `enums.ts`.
* [`src/features/Maintenance/utils.ts`](diffhunk://#diff-0915d599ca21796612fafbe803a12b87621f8cdc7a017bcb99aeb1a4b82f94f4R4-R6): Updated the `maintenanceType` to use the `MaintenanceTypes` enum from `enums.ts`.
* [`src/features/Transfer/utils.ts`](diffhunk://#diff-079279e69a8d19a4c44a2a370c9629aeee7e1a358f7f91ef7222c9bb69797e60R4-R14): Updated the `transferStatus` to use the `TransferStatuses` enum from `enums.ts` and changed references from `downtime_status` to `status`. [[1]](diffhunk://#diff-079279e69a8d19a4c44a2a370c9629aeee7e1a358f7f91ef7222c9bb69797e60R4-R14) [[2]](diffhunk://#diff-079279e69a8d19a4c44a2a370c9629aeee7e1a358f7f91ef7222c9bb69797e60L23-R24) [[3]](diffhunk://#diff-079279e69a8d19a4c44a2a370c9629aeee7e1a358f7f91ef7222c9bb69797e60L34-R35)

### Type Updates:

* [`src/features/Equipment/types.ts`](diffhunk://#diff-150429a872899a659a4324d5a4d7708c9f100453a050a054dbdca08a8f7b85fbL9-R9): Updated the `EquipmentType` interface and `equipmentSelection` to reflect the change from `state` to `status`. [[1]](diffhunk://#diff-150429a872899a659a4324d5a4d7708c9f100453a050a054dbdca08a8f7b85fbL9-R9) [[2]](diffhunk://#diff-150429a872899a659a4324d5a4d7708c9f100453a050a054dbdca08a8f7b85fbL18-R18)
* [`src/features/Transfer/types.ts`](diffhunk://#diff-8d430cf55e6e4e85748dfaae0f516a3ca7e0ae2307915958a0bf7cfeef9c2b1cL38-R38): Updated the `transferSelection` to reflect the change from `downtime_status` to `status`.