### PR TITLE
Add type checking step to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
+    - name: Run typecheck
+      run: pnpm tsc
+
     - name: Run linter
       run: pnpm lint
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/main.yml` file. The change adds a new step to run a type check after installing dependencies. 

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R33-R35): Added a step to run `pnpm tsc` for type checking after installing dependencies.