### PR TITLE
Export pgEnums

### DIFF
--- a/src/features/Downtime/schema.ts
+++ b/src/features/Downtime/schema.ts
@@ -4,7 +4,7 @@ import { equipment } from '../Equipment/schema';
 import { department } from '../Department/schema';
 import { DowntimeStatuses } from '../../enums';
 
-const status = pgEnum('downtimeStatus', DowntimeStatuses);
+export const status = pgEnum('downtimeStatus', DowntimeStatuses);
 
 export const downtime = pgTable(
   'downtime',

--- a/src/features/Equipment/schema.ts
+++ b/src/features/Equipment/schema.ts
@@ -2,8 +2,8 @@ import { pgEnum, pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 import { department } from '../Department/schema';
 import { EquipmentStatuses, EquipmentTypes } from '../../enums';
 
-const type = pgEnum('equipmentType', EquipmentTypes);
-const status = pgEnum('equipmentState', EquipmentStatuses);
+export const type = pgEnum('equipmentType', EquipmentTypes);
+export const status = pgEnum('equipmentState', EquipmentStatuses);
 
 export const equipment = pgTable('equipment', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/src/features/Maintenance/schema.ts
+++ b/src/features/Maintenance/schema.ts
@@ -3,7 +3,7 @@ import { technician } from '../Technician/schema';
 import { equipment } from '../Equipment/schema';
 import { MaintenanceTypes } from '../../enums';
 
-const type = pgEnum('maintenanceType', MaintenanceTypes);
+export const type = pgEnum('maintenanceType', MaintenanceTypes);
 
 export const maintenance = pgTable(
   'maintenance',

--- a/src/features/Transfer/schema.ts
+++ b/src/features/Transfer/schema.ts
@@ -4,7 +4,7 @@ import { equipment } from '../Equipment/schema';
 import { department } from '../Department/schema';
 import { TransferStatuses } from '../../enums';
 
-const status = pgEnum('statuses', TransferStatuses);
+export const status = pgEnum('statuses', TransferStatuses);
 
 export const transfer = pgTable(
   'transfer',

--- a/src/features/User/schema.ts
+++ b/src/features/User/schema.ts
@@ -2,7 +2,7 @@ import { pgTable, uuid, varchar, pgEnum } from 'drizzle-orm/pg-core';
 import { department } from '../Department/schema';
 import { Roles } from '../../enums';
 
-const roles = pgEnum('roles', Roles);
+export const roles = pgEnum('userRole', Roles);
 
 export const user = pgTable('user', {
   id: uuid('id').primaryKey().defaultRandom(),


### PR DESCRIPTION
This pull request focuses on updating the export statements for enums in various schema files to ensure they are properly exported for use in other modules. The most important changes include modifying the export statements for enums in the `Downtime`, `Equipment`, `Maintenance`, `Transfer`, and `User` schema files.

Export updates for enums:

* [`src/features/Downtime/schema.ts`](diffhunk://#diff-d8f86fbdb0fc2c6ab8f1a83116a2f02143fb4a65bc36a17941b276462ebf5226L7-R7): Changed the `status` enum to be exported.
* [`src/features/Equipment/schema.ts`](diffhunk://#diff-423989d60c82e764773d7612d234a29aedcded70c457a5ded83d1d2fe3a21244L5-R6): Changed the `type` and `status` enums to be exported.
* [`src/features/Maintenance/schema.ts`](diffhunk://#diff-4f76dab2a529920bdaa96ed7c19da6d937ccf6f96f5e14817760d331f474e8dcL6-R6): Changed the `type` enum to be exported.
* [`src/features/Transfer/schema.ts`](diffhunk://#diff-95261da1935f76f70709ad47419f31f8b464cdc170ce3abba9d4284be3f4d8f1L7-R7): Changed the `status` enum to be exported.
* [`src/features/User/schema.ts`](diffhunk://#diff-dd7b004196592a9122b2f3d0f6b8e0a094ef6ae74db414cf85953bdc2dcb505fL5-R5): Changed the `roles` enum to be exported and renamed it to `userRole`.