### PR TITLE
downtime report listing last year implemented

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "db:migrate": "npx drizzle-kit migrate",
     "db:migrate:local": "dotenv -e .env.development.local -- npx drizzle-kit migrate",
     "db:generate": "npx drizzle-kit generate",
+    "db:generate:local": "dotenv -e .env.development.local -- npx drizzle-kit generate",
     "db:seed": "ts-node src/seed.ts",
     "db:seed:local": "dotenv -e .env.development.local -- ts-node src/seed.ts",
     "start": "tsc && nodemon src/index.ts",

--- a/src/features/Report/DowntimeReport/controller.ts
+++ b/src/features/Report/DowntimeReport/controller.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from 'express';
+import { eq, gte, sql } from 'drizzle-orm';
+import { db } from '../../../db/config/db_connect';
+import { downtime } from '../../Downtime/schema';
+import { equipment } from '../../Equipment/schema';
+import { user } from '../../User/schema';
+import { department } from '../../Department/schema';
+
+/**
+ * Controller class for handling equipment downtime report requests
+ *
+ * Provides methods to retrieve and format equipment downtime information
+ * from various related entities including equipment, departments, and users.
+ */
+export class DowntimeReportController {
+  /**
+   * Handles GET request for equipment downtime report from the last year
+   *
+   * @async
+   * @param {Request} req - Express request object
+   * @param {Response} res - Express response object
+   * @returns {Promise<void>} Sends JSON response with report data or error message
+   * @throws {Error} Will throw an error if database query fails
+   *
+   * @remarks
+   * Fetches downtime records from the last 365 days with related entity information.
+   * Response data includes:
+   * - Equipment name
+   * - Downtime cause
+   * - Responsible department name
+   * - Receiving user name
+   * - Formatted timestamp
+   *
+   * @example
+   * Successful response format:
+   * [
+   *   {
+   *     "equipmentName": "Generator A",
+   *     "cause": "Maintenance",
+   *     "departmentName": "Facilities",
+   *     "receiverName": "John Doe",
+   *     "downtimeDate": "2023-07-15T08:00:00.000Z"
+   *   },
+   *   ...
+   * ]
+   */
+  async getLastYearEquipmentDowntime(req: Request, res: Response) {
+    try {
+      const oneYearAgo = new Date();
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+      const oneYearAgoISO = oneYearAgo.toISOString();
+
+      const report = await db
+        .select({
+          equipmentName: equipment.name,
+          cause: downtime.cause,
+          departmentName: department.name,
+          receiverName: user.name,
+          downtimeDate: sql<Date>`${downtime.date}::timestamp`
+        })
+        .from(downtime)
+        .innerJoin(equipment, eq(downtime.id_equipment, equipment.id))
+        .innerJoin(user, eq(downtime.id_receiver, user.id))
+        .innerJoin(department, eq(downtime.id_dep_receiver, department.id))
+        .where(gte(downtime.date, oneYearAgoISO))
+        .orderBy(sql`${downtime.date} DESC`);
+
+      res.json(report);
+    } catch (error) {
+      console.error('Error fetching downtime report:', error);
+      res.status(500).json({ message: 'Failed to fetch downtime report' });
+    }
+  }
+}

--- a/src/features/Report/DowntimeReport/router.ts
+++ b/src/features/Report/DowntimeReport/router.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { DowntimeReportController } from './controller';
+
+/**
+ * Creates and configures the downtime report router with associated routes.
+ *
+ * This router handles equipment downtime reporting features, providing endpoints
+ * for accessing historical downtime data. It uses existing database schemas through
+ * Drizzle ORM and does not require separate models.
+ *
+ * @returns {Router} Express router configured with downtime report endpoints
+ *
+ * @route GET /downtime-last-year
+ * @description Retrieves equipment downtime records from the last year, including
+ *              cause, receiving department, and responsible user
+ * @produces application/json
+ * @response {EquipmentDowntimeReport[]} 200 - Array of downtime records
+ * @response {ErrorResponse} 500 - Server error response
+ */
+export const downtimeReportRouter = () => {
+  const router = Router();
+  const controller = new DowntimeReportController();
+
+  // Register routes
+  router.get('/downtime-last-year', controller.getLastYearEquipmentDowntime);
+
+  return router;
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,6 +9,7 @@ import { departmentRouter } from './features/Department/router';
 import { downtimeRouter } from './features/Downtime/router';
 import { maintenanceRouter } from './features/Maintenance/router';
 import { authRouter } from './features/Auth/router';
+import { downtimeReportRouter } from './features/Report/DowntimeReport/router';
 
 /**
  * Configures and returns the main application router with all feature routes.
@@ -38,5 +39,6 @@ export const appRouter = (appModels: Models): Router => {
   router.use('/downtime', downtimeRouter(appModels.downtimeModel));
   router.use('/maintenance', maintenanceRouter(appModels.maintenanceModel));
   router.use('/auth', authRouter(appModels.userModel));
+  router.use('/report', downtimeReportRouter());
   return router;
 };


### PR DESCRIPTION
This pull request introduces a new feature for generating and retrieving equipment downtime reports from the last year. The changes include adding new scripts for local database operations, creating a controller and router for the downtime report, and integrating the new router into the main application router.

Key changes:

### New Feature: Equipment Downtime Report

* **Controller for Downtime Report**:
  * Added `DowntimeReportController` class in `src/features/Report/DowntimeReport/controller.ts` to handle GET requests for equipment downtime reports from the last year. This includes fetching and formatting data from related entities such as equipment, departments, and users.

* **Router for Downtime Report**:
  * Created `downtimeReportRouter` function in `src/features/Report/DowntimeReport/router.ts` to configure routes for the downtime report feature. This router handles endpoints for accessing historical downtime data.

### Integration and Configuration

* **Main Application Router**:
  * Integrated the newly created `downtimeReportRouter` into the main application router in `src/router.ts` by importing it and adding it to the main router configuration. [[1]](diffhunk://#diff-bb8ff0dd16ff286e4086240831f70dd9233de8896f2f50219eeff29414affe64R12) [[2]](diffhunk://#diff-bb8ff0dd16ff286e4086240831f70dd9233de8896f2f50219eeff29414affe64R42)

### Script Enhancements

* **Local Database Operations**:
  * Added a new script `db:generate:local` in `package.json` to generate database schema locally using environment variables from `.env.development.local`.
  
### How to Test
```bash
curl -X GET http://localhost:8080/api/report/downtime-last-year
```