### PR TITLE
state renamed for status in src/features/Equipment/utils.ts

### DIFF
--- a/src/features/Equipment/utils.ts
+++ b/src/features/Equipment/utils.ts
@@ -29,7 +29,7 @@ export type EquipmentQuery = {
   id?: string;
   name?: string;
   type?: string;
-  state?: string;
+  status?: string;
   id_department?: string;
   acquisition_date?: string;
 };
@@ -50,7 +50,7 @@ export function EquipmentQueryBuilder(query: EquipmentQuery): SQL[] {
   if (query.id) filters.push(eq(equipment.id, query.id));
   if (query.name) filters.push(eq(equipment.name, query.name));
   if (query.type) filters.push(eq(equipment.type, query.type));
-  if (query.state) filters.push(eq(equipment, query.state));
+  if (query.status) filters.push(eq(equipment, query.status));
   if (query.id_department) filters.push(eq(equipment.id_department, query.id_department));
   if (query.acquisition_date) filters.push(eq(equipment.acquisition_date, query.acquisition_date));
   return filters;


### PR DESCRIPTION
This pull request involves modifications to the `EquipmentQuery` type and its associated query builder function in the `src/features/Equipment/utils.ts` file. The changes primarily focus on renaming a property for consistency and clarity.

Changes to `EquipmentQuery` type and query builder function:

* [`src/features/Equipment/utils.ts`](diffhunk://#diff-4468c7ebc25c11fd3d63f3ed87d5897af5eaf593d9fcc05208900eac6a9eda09L32-R32): Renamed the `state` property to `status` in the `EquipmentQuery` type to better reflect its purpose.
* [`src/features/Equipment/utils.ts`](diffhunk://#diff-4468c7ebc25c11fd3d63f3ed87d5897af5eaf593d9fcc05208900eac6a9eda09L53-R53): Updated the `EquipmentQueryBuilder` function to use the new `status` property instead of the old `state` property.